### PR TITLE
Refactor services and views for async/await

### DIFF
--- a/Recky/Friend/FriendRequestsViewModel.swift
+++ b/Recky/Friend/FriendRequestsViewModel.swift
@@ -8,8 +8,12 @@ class FriendRequestsViewModel: ObservableObject {
 
     func loadRequests() {
         guard let uid = Auth.auth().currentUser?.uid else { return }
-        service.fetchFriendRequests(for: uid) { [weak self] reqs in
-            self?.requests = reqs
+        Task { [weak self] in
+            do {
+                self?.requests = try await service.fetchFriendRequests(for: uid)
+            } catch {
+                self?.requests = []
+            }
         }
     }
 

--- a/Recky/ProfileView.swift
+++ b/Recky/ProfileView.swift
@@ -138,8 +138,15 @@ struct ProfileView: View {
 
     func fetchMyStats() {
         guard let uid = Auth.auth().currentUser?.uid else { return }
-        RecommendationStatsService.fetchDetailedStats(for: uid) { stats in
-            myStats = stats
+        Task {
+            do {
+                let stats = try await RecommendationStatsService.fetchDetailedStats(for: uid)
+                await MainActor.run {
+                    myStats = stats
+                }
+            } catch {
+                await MainActor.run { myStats = nil }
+            }
         }
     }
 }

--- a/Recky/Recommendation/Detail/RecommendationDetailViewModel.swift
+++ b/Recky/Recommendation/Detail/RecommendationDetailViewModel.swift
@@ -36,16 +36,16 @@ class RecommendationDetailViewModel: ObservableObject {
                 if let vote = nextVote {
                     var updated = recommendation
                     updated.vote = vote
-                    RecommendationStatsService.updateStatsInFirestore(for: updated, change: .increment)
+                    try await RecommendationStatsService.updateStatsInFirestore(for: updated, change: .increment)
                     if let previous = previousVote, previous != vote {
                         var previousRec = recommendation
                         previousRec.vote = previous
-                        RecommendationStatsService.updateStatsInFirestore(for: previousRec, change: .decrement)
+                        try await RecommendationStatsService.updateStatsInFirestore(for: previousRec, change: .decrement)
                     }
                 } else if let previous = previousVote {
                     var previousRec = recommendation
                     previousRec.vote = previous
-                    RecommendationStatsService.updateStatsInFirestore(for: previousRec, change: .decrement)
+                    try await RecommendationStatsService.updateStatsInFirestore(for: previousRec, change: .decrement)
                 }
             } catch {
                 print("Failed to update vote: \(error)")

--- a/Recky/Recommendation/RecommendationService.swift
+++ b/Recky/Recommendation/RecommendationService.swift
@@ -6,7 +6,7 @@ class RecommendationService {
     private let db = Firestore.firestore()
     private init() {}
 
-    func send(_ rec: Recommendation, completion: @escaping (Result<Void, Error>) -> Void) {
+    func send(_ rec: Recommendation) async throws {
         var data: [String: Any] = [
             "fromUID": rec.fromUID,
             "fromUsername": rec.fromUsername ?? "",
@@ -22,11 +22,13 @@ class RecommendationService {
             data["notes"] = notes
         }
 
-        db.collection("recommendations").addDocument(data: data) { error in
-            if let error = error {
-                completion(.failure(error))
-            } else {
-                completion(.success(()))
+        try await withCheckedThrowingContinuation { continuation in
+            db.collection("recommendations").addDocument(data: data) { error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Convert Friend and Recommendation services to `async throws`
- Use structured concurrency for friend searches, recommendation sending, and stats updates
- Update views and view models to await new async APIs

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a26ba8425883269c118e6be6747a45