### PR TITLE
Refactor recommendation detail view logic into view model

### DIFF
--- a/Recky/Recommendation/Detail/RecommendationBaseDetailView.swift
+++ b/Recky/Recommendation/Detail/RecommendationBaseDetailView.swift
@@ -5,7 +5,6 @@ struct RecommendationBaseDetailView: View {
     var titlePrefix: String
     var editableVote: Bool
     var editableNote: Bool
-    @State private var currentVote: Bool?
     @State private var voteNoteText: String = ""
     @State private var originalNoteText: String = ""
     @FocusState private var isNoteFocused: Bool
@@ -33,20 +32,20 @@ struct RecommendationBaseDetailView: View {
                 HStack(spacing: 20) {
                     Button(action: { toggleVote(true) }) {
                         Image(
-                            systemName: currentVote == true
+                            systemName: viewModel.recommendation.vote == true
                                 ? "hand.thumbsup.fill" : "hand.thumbsup"
                         )
                         .font(.title2)
-                        .foregroundColor(currentVote == true ? .blue : .gray)
+                        .foregroundColor(viewModel.recommendation.vote == true ? .blue : .gray)
                     }
 
                     Button(action: { toggleVote(false) }) {
                         Image(
-                            systemName: currentVote == false
+                            systemName: viewModel.recommendation.vote == false
                                 ? "hand.thumbsdown.fill" : "hand.thumbsdown"
                         )
                         .font(.title2)
-                        .foregroundColor(currentVote == false ? .red : .gray)
+                        .foregroundColor(viewModel.recommendation.vote == false ? .red : .gray)
                     }
                 }
                 .padding(.top, 8)
@@ -128,7 +127,6 @@ struct RecommendationBaseDetailView: View {
         }
         .padding()
         .onAppear {
-            currentVote = viewModel.recommendation.vote
             voteNoteText = viewModel.recommendation.voteNote ?? ""
             originalNoteText = voteNoteText
         }
@@ -136,9 +134,7 @@ struct RecommendationBaseDetailView: View {
 
     private func toggleVote(_ newVote: Bool) {
         guard editableVote else { return }
-        let nextVote: Bool? = (currentVote == newVote) ? nil : newVote
-        currentVote = nextVote
-        viewModel.toggleVote(newVote)
+        Task { await viewModel.toggleVote(newVote) }
     }
 
 
@@ -171,7 +167,9 @@ struct RecommendationBaseDetailView: View {
 
     private func saveVoteNote() {
         isNoteFocused = false
-        viewModel.saveVoteNote(voteNoteText)
-        withAnimation { originalNoteText = voteNoteText }
+        Task {
+            await viewModel.saveVoteNote(voteNoteText)
+            withAnimation { originalNoteText = voteNoteText }
+        }
     }
 }

--- a/Recky/Recommendation/Detail/RecommendationDetailView.swift
+++ b/Recky/Recommendation/Detail/RecommendationDetailView.swift
@@ -46,7 +46,7 @@ struct RecommendationDetailView: View {
         .navigationDestination(item: $selectedPrefill) { rec in
             SendRecommendationView(prefilledRecommendation: rec)
         }
-        .onAppear { viewModel.markViewedIfNeeded() }
+        .task { await viewModel.markViewedIfNeeded() }
     }
 }
         

--- a/Recky/Recommendation/Detail/SentRecommendationDetailView.swift
+++ b/Recky/Recommendation/Detail/SentRecommendationDetailView.swift
@@ -1,16 +1,23 @@
 import SwiftUI
 
 struct SentRecommendationDetailView: View {
-    var recommendation: Recommendation
+    @StateObject private var viewModel: RecommendationDetailViewModel
+
+    init(recommendation: Recommendation) {
+        _viewModel = StateObject(wrappedValue: RecommendationDetailViewModel(recommendation: recommendation))
+    }
 
     var body: some View {
         RecommendationBaseDetailView(
-            recommendation: recommendation,
+            viewModel: viewModel,
             titlePrefix: "To @",
             editableVote: false,
             editableNote: false
         )
-        .navigationTitle(recommendation.toUsername.map { "To @\($0)" } ?? "Sent Recommendation")
+        .navigationTitle(
+            viewModel.recommendation.toUsername.map { "To @\($0)" } ?? "Sent Recommendation"
+        )
         .navigationBarTitleDisplayMode(.inline)
+        .task { await viewModel.markViewedIfNeeded() }
     }
 }


### PR DESCRIPTION
## Summary
- centralize vote, note, and view tracking in `RecommendationDetailViewModel`
- bind detail views to `RecommendationDetailViewModel` state
- expose async actions for UI and mark recommendations viewed on appearance

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a26e3ed3948326aed13989ebb0a964