### PR TITLE
Store username with friend requests

### DIFF
--- a/Recky/Friend/FriendRequestsView.swift
+++ b/Recky/Friend/FriendRequestsView.swift
@@ -14,7 +14,7 @@ struct FriendRequestsView: View {
 
                     HStack(spacing: 24) {
                         Button("Accept") {
-                            viewModel.acceptRequest(from: request.uid) {
+                            viewModel.acceptRequest(uid: request.uid, username: request.username) {
                                 onFriendAccepted()
                             }
                         }
@@ -22,7 +22,7 @@ struct FriendRequestsView: View {
                         .tint(.blue)
 
                         Button("Ignore") {
-                            viewModel.ignoreRequest(from: request.uid)
+                            viewModel.ignoreRequest(uid: request.uid, username: request.username)
                         }
                         .buttonStyle(.bordered)
                         .tint(.red)

--- a/Recky/Friend/FriendRequestsViewModel.swift
+++ b/Recky/Friend/FriendRequestsViewModel.swift
@@ -17,17 +17,17 @@ class FriendRequestsViewModel: ObservableObject {
         }
     }
 
-    func acceptRequest(from uid: String, completion: @escaping () -> Void = {}) {
+    func acceptRequest(uid: String, username: String, completion: @escaping () -> Void = {}) {
         guard let myUID = Auth.auth().currentUser?.uid else { return }
-        service.acceptRequest(from: uid, currentUID: myUID) { [weak self] in
+        service.acceptRequest(from: uid, otherUsername: username, currentUID: myUID) { [weak self] in
             self?.loadRequests()
             completion()
         }
     }
 
-    func ignoreRequest(from uid: String) {
+    func ignoreRequest(uid: String, username: String) {
         guard let myUID = Auth.auth().currentUser?.uid else { return }
-        service.ignoreRequest(from: uid, currentUID: myUID) { [weak self] in
+        service.ignoreRequest(from: uid, otherUsername: username, currentUID: myUID) { [weak self] in
             self?.loadRequests()
         }
     }

--- a/Recky/Friend/FriendsPageView.swift
+++ b/Recky/Friend/FriendsPageView.swift
@@ -143,7 +143,7 @@ struct FriendsPageView: View {
         guard let myUID = Auth.auth().currentUser?.uid else { return }
         let db = Firestore.firestore()
         db.collection("users").document(myUID).addSnapshotListener { snapshot, _ in
-            let requests = snapshot?.data()?["friendRequests"] as? [String] ?? []
+            let requests = snapshot?.data()?["friendRequests"] as? [[String: Any]] ?? []
             requestCount = requests.count
         }
     }

--- a/Recky/ProfileView.swift
+++ b/Recky/ProfileView.swift
@@ -131,7 +131,7 @@ struct ProfileView: View {
                 guard let doc = docSnapshot, let data = doc.data() else {
                     return
                 }
-                let requests = data["friendRequests"] as? [String] ?? []
+                let requests = data["friendRequests"] as? [[String: Any]] ?? []
                 pendingRequestCount = requests.count
             }
     }


### PR DESCRIPTION
## Summary
- Store uid/username objects in friend request arrays and fetch them in a single read
- Pass request usernames through FriendRequestsViewModel and update accept/ignore paths
- Count pending requests using new object structure

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a26f68cc888326b3aca1712f195a04