### PR TITLE
Use Firestore transactions for stats and consume aggregated counters

### DIFF
--- a/Recky/Recommendation/Detail/RecommendationDetailViewModel.swift
+++ b/Recky/Recommendation/Detail/RecommendationDetailViewModel.swift
@@ -34,20 +34,11 @@ class RecommendationDetailViewModel: ObservableObject {
         recommendation.vote = nextVote
         do {
             try await repository.vote(recommendationID: id, vote: nextVote)
-            if let vote = nextVote {
-                var updated = recommendation
-                updated.vote = vote
-                try await RecommendationStatsService.updateStatsInFirestore(for: updated, change: .increment)
-                if let previous = previousVote, previous != vote {
-                    var previousRec = recommendation
-                    previousRec.vote = previous
-                    try await RecommendationStatsService.updateStatsInFirestore(for: previousRec, change: .decrement)
-                }
-            } else if let previous = previousVote {
-                var previousRec = recommendation
-                previousRec.vote = previous
-                try await RecommendationStatsService.updateStatsInFirestore(for: previousRec, change: .decrement)
-            }
+            try await RecommendationStatsService.updateStatsInFirestore(
+                for: recommendation,
+                previousVote: previousVote,
+                newVote: nextVote
+            )
         } catch {
             print("Failed to update vote: \(error)")
             recommendation.vote = previousVote

--- a/Recky/Recommendation/RecommendationRepository.swift
+++ b/Recky/Recommendation/RecommendationRepository.swift
@@ -46,6 +46,11 @@ class RecommendationRepository {
             data["notes"] = notes
         }
         _ = try await db.collection("recommendations").addDocument(data: data)
+        try await RecommendationStatsService.updateStatsInFirestore(
+            for: rec,
+            previousVote: nil,
+            newVote: nil
+        )
     }
 
     func vote(recommendationID: String, vote: Bool?) async throws {

--- a/Recky/Recommendation/RecommendationService.swift
+++ b/Recky/Recommendation/RecommendationService.swift
@@ -31,5 +31,10 @@ class RecommendationService {
                 }
             }
         }
+        try await RecommendationStatsService.updateStatsInFirestore(
+            for: rec,
+            previousVote: nil,
+            newVote: nil
+        )
     }
 }


### PR DESCRIPTION
## Summary
- compute friend and detailed stats from aggregated `stats.*` fields on each user
- update per-user recommendation counters within Firestore transactions
- hook send/vote flows into the transactional updater
- document where Cloud Functions could validate stat updates

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a27074bd3083269a0c4d85278a9253