### PR TITLE
Refactor friend features to use async service

### DIFF
--- a/Recky/Friend/FriendRequestsViewModel.swift
+++ b/Recky/Friend/FriendRequestsViewModel.swift
@@ -19,16 +19,26 @@ class FriendRequestsViewModel: ObservableObject {
 
     func acceptRequest(uid: String, username: String, completion: @escaping () -> Void = {}) {
         guard let myUID = Auth.auth().currentUser?.uid else { return }
-        service.acceptRequest(from: uid, otherUsername: username, currentUID: myUID) { [weak self] in
-            self?.loadRequests()
-            completion()
+        Task { [weak self] in
+            do {
+                try await service.acceptRequest(from: uid, otherUsername: username, currentUID: myUID)
+                await MainActor.run { self?.loadRequests() }
+                completion()
+            } catch {
+                // Ignore error for now
+            }
         }
     }
 
     func ignoreRequest(uid: String, username: String) {
         guard let myUID = Auth.auth().currentUser?.uid else { return }
-        service.ignoreRequest(from: uid, otherUsername: username, currentUID: myUID) { [weak self] in
-            self?.loadRequests()
+        Task { [weak self] in
+            do {
+                try await service.ignoreRequest(from: uid, otherUsername: username, currentUID: myUID)
+                await MainActor.run { self?.loadRequests() }
+            } catch {
+                // Ignore error for now
+            }
         }
     }
 }

--- a/Recky/Friend/FriendSearchViewModel.swift
+++ b/Recky/Friend/FriendSearchViewModel.swift
@@ -9,8 +9,13 @@ class FriendSearchViewModel: ObservableObject {
 
     func sendFriendRequestByEmail() {
         guard let myUID = Auth.auth().currentUser?.uid else { return }
-        service.sendFriendRequestByEmail(searchEmail, from: myUID) { [weak self] msg in
-            self?.message = msg
+        Task { [weak self] in
+            do {
+                let msg = try await service.sendFriendRequestByEmail(searchEmail, from: myUID)
+                await MainActor.run { self?.message = msg }
+            } catch {
+                await MainActor.run { self?.message = "Failed to send request." }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add async friend APIs for listing friends, sending requests, accepting/ignoring, and removing friends
- Update friend view models and pages to use FriendService instead of direct Firestore access

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a2734e812483268aeaf692e324d2cd